### PR TITLE
Add legal pages and lint setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Node modules
+node_modules/
+
+# Logs
+npm-debug.log*
+
+# Mac
+.DS_Store
+
+# Misc
+.env

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,12 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "color-no-invalid-hex": true,
+    "font-family-no-duplicate-names": true,
+    "unit-no-unknown": true,
+    "block-no-empty": true,
+    "selector-pseudo-class-no-unknown": [true, {"ignorePseudoClasses": ["global"]}],
+    "declaration-block-no-duplicate-properties": true,
+    "declaration-block-no-shorthand-property-overrides": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -72,8 +72,13 @@ Führe nach Konfigurationsänderungen folgende Befehle aus:
 
 ```bash
 # CSS-Analyse
+# via npm
+npm run lint:css
+# alternativ direkt
 npx stylelint style.css
 # HTML-Analyse
+npm run lint:html
+# alternativ
 npx htmlhint index.html
 # JavaScript-Analyse
 npx eslint script.js

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Datenschutzerklärung – Physio Synergie</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Poppins:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="legal">
+  <main class="section">
+    <h1>Datenschutzerklärung</h1>
+    <p>Wir behandeln Ihre Daten vertraulich und entsprechend der gesetzlichen Vorschriften.</p>
+    <p>Es werden nur die Daten verarbeitet, die für die Terminabwicklung und Kommunikation notwendig sind.</p>
+    <p>Bei Fragen wenden Sie sich an <a href="mailto:Physiosynergie10@gmail.com">Physiosynergie10@gmail.com</a>.</p>
+    <a href="index.html">Zurück zur Startseite</a>
+  </main>
+</body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Impressum – Physio Synergie</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Poppins:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="legal">
+  <main class="section">
+    <h1>Impressum</h1>
+    <p>Angaben gemäß § 5 TMG</p>
+    <p>Physio Synergie – Florina Frunza BSc<br>
+    Fischeraustraße 13/1 – Medcenter Nord<br>
+    1210 Wien</p>
+    <p>Kontakt: <a href="mailto:Physiosynergie10@gmail.com">Physiosynergie10@gmail.com</a></p>
+    <p>Tel.: <a href="tel:+4368120520482">+43 681 20520482</a></p>
+    <a href="index.html">Zurück zur Startseite</a>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -21,9 +21,9 @@
 </head>
 <body>
   <header>
-    <div class="logo-container">
+    <a href="index.html" class="logo-container" aria-label="Physio Synergie Startseite">
       <img src="img/Logo-Physiosynergie.jpeg" alt="Logo Physio Synergie" />
-    </div>
+    </a>
     <nav>
       <a href="#leistungen">Leistungen</a>
       <a href="#kontakt">Kontakt</a>
@@ -155,8 +155,8 @@
   <footer>
     <p>
       &copy; 2025 Physio Synergie – Florina Frunza |
-      <a href="#">Impressum</a> |
-      <a href="#">Datenschutz</a>
+      <a href="impressum.html">Impressum</a> |
+      <a href="datenschutz.html">Datenschutz</a>
     </p>
   </footer>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "physio-synergie",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "lint:css": "stylelint style.css",
+    "lint:html": "htmlhint index.html Danke.html impressum.html datenschutz.html"
+  },
+  "devDependencies": {
+    "stylelint": "^16.0.0",
+    "stylelint-config-standard": "^36.0.0",
+    "htmlhint": "^1.1.5"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,3 +1,4 @@
+// Tooltips für die Leistungskarten werden rein per CSS umgesetzt
 document.addEventListener('DOMContentLoaded', () => {
   /* Smooth Anchor Scroll */
   document.querySelectorAll('a[href^="#"]').forEach((anchor) => {

--- a/style.css
+++ b/style.css
@@ -166,13 +166,16 @@ footer {
 }
 
 /* Logo sichtbar machen */
-.logo-container img {
+.logo-container {
   position: absolute;
   top: -30px;
   left: 2rem;
+  z-index: 1100;
+}
+
+.logo-container img {
   max-height: 100px;
   width: auto;
-  z-index: 1100;
 }
 
 /* Newsletter */
@@ -225,4 +228,14 @@ body.thank-you a {
   padding: 0.75rem 1.5rem;
   border-radius: 5px;
   font-weight: bold;
+}
+
+/* Legal pages */
+body.legal main.section {
+  max-width: 800px;
+  margin: 4rem auto;
+}
+
+body.legal a {
+  color: var(--blue-gray);
 }


### PR DESCRIPTION
## Summary
- add legal pages for imprint and data privacy
- link legal pages in footer
- add stylelint config and package.json with lint scripts
- update README with npm commands
- tweak logo positioning and add legal styles
- document that tooltips use CSS only

## Testing
- `npx stylelint style.css`
- `npx htmlhint index.html Danke.html impressum.html datenschutz.html`
- `git push` *(fails: `origin` does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_684af4c55418832aa7a18bd67f41cab9